### PR TITLE
Include dependency & references shield in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ As of April 5, 2017, Parse, LLC has transferred this code to the parse-community
  [maven-link]: https://maven-badges.herokuapp.com/maven-central/com.parse/parse-android
  
  [dependencies-svg]: https://www.versioneye.com/java/com.parse:parse-android/badge.svg?style=flat-square
- [dependencies-link]: https://www.versioneye.com/java/com.parse:parse-android/#dialog_dependency_badge
+ [dependencies-link]: https://www.versioneye.com/java/com.parse:parse-android
  
  [references-svg]: https://www.versioneye.com/java/com.parse:parse-android/reference_badge.svg?style=flat-square
- [references-link]: https://www.versioneye.com/java/com.parse:parse-android/#dialog_ref_badge
+ [references-link]: https://www.versioneye.com/java/com.parse:parse-android/references
  
  [license-svg]: https://img.shields.io/badge/license-BSD-lightgrey.svg
  [license-link]: https://github.com/parse-community/Parse-SDK-Android/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Parse SDK for Android
+
+[![Maven Central][maven-svg]][maven-link]
+[![Dependencies][dependencies-svg]][dependencies-link]
+[![References][references-svg]][references-link]
+[![License][license-svg]][license-link]
+
 [![Build Status][build-status-svg]][build-status-link]
 [![Coverage Status][coverage-status-svg]][coverage-status-link]
-[![Maven Central][maven-svg]][maven-link]
-[![License][license-svg]][license-link]
 
 [![Join Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/ParsePlatform/Chat)
 
@@ -69,18 +73,27 @@ As of April 5, 2017, Parse, LLC has transferred this code to the parse-community
 
  [latest]: https://search.maven.org/remote_content?g=com.parse&a=parse-android&v=LATEST
  [snap]: https://oss.jfrog.org/artifactory/oss-snapshot-local/com/parse/parse-android/
+ 
+ [maven-svg]: https://maven-badges.herokuapp.com/maven-central/com.parse/parse-android/badge.svg?style=flat
+ [maven-link]: https://maven-badges.herokuapp.com/maven-central/com.parse/parse-android
+ 
+ [dependencies-svg]: https://www.versioneye.com/java/com.parse:parse-android/badge.svg?style=flat-square
+ [dependencies-link]: https://www.versioneye.com/java/com.parse:parse-android/#dialog_dependency_badge
+ 
+ [references-svg]: https://www.versioneye.com/java/com.parse:parse-android/reference_badge.svg?style=flat-square
+ [references-link]: https://www.versioneye.com/java/com.parse:parse-android/#dialog_ref_badge
+ 
+ [license-svg]: https://img.shields.io/badge/license-BSD-lightgrey.svg
+ [license-link]: https://github.com/parse-community/Parse-SDK-Android/blob/master/LICENSE
 
  [build-status-svg]: https://travis-ci.org/parse-community/Parse-SDK-Android.svg?branch=master
  [build-status-link]: https://travis-ci.org/parse-community/Parse-SDK-Android
+ 
  [coverage-status-svg]: https://coveralls.io/repos/parse-community/Parse-SDK-Android/badge.svg?branch=master&service=github
  [coverage-status-link]: https://coveralls.io/github/parse-community/Parse-SDK-Android?branch=master
- [maven-svg]: https://maven-badges.herokuapp.com/maven-central/com.parse/parse-android/badge.svg?style=flat
- [maven-link]: https://maven-badges.herokuapp.com/maven-central/com.parse/parse-android
 
  [parseui-link]: https://github.com/parse-community/ParseUI-Android
  [parselivequery-link]: https://github.com/parse-community/ParseLiveQuery-Android
+ 
  [parsefacebookutils-link]: https://github.com/parse-community/ParseFacebookUtils-Android
  [parsetwitterutils-link]: https://github.com/parse-community/ParseTwitterUtils-Android
-
- [license-svg]: https://img.shields.io/badge/license-BSD-lightgrey.svg
- [license-link]: https://github.com/parse-community/Parse-SDK-Android/blob/master/LICENSE


### PR DESCRIPTION
Add a dependency shield that determines if the dependencies in the repository are up to date. If not, the shield will indicate out of date and this will notify contributors that the libraries need to be updated.

In addition, a references shield is included which shows the number of projects that reference this project.

These two badges are included in the Android-SDK-iOS-OSX project and it is nice to stay consistent between the various projects of Parse. Badges are obtained via VersionEye.